### PR TITLE
Add Evan Jenkins data

### DIFF
--- a/data/congress_legislators/wv/congress_legislator_wv_evan-jenkins.json
+++ b/data/congress_legislators/wv/congress_legislator_wv_evan-jenkins.json
@@ -49,7 +49,7 @@
     {
       "address": "1609 Longworth House Office Building; Washington DC 20515-4803", 
       "district": 3, 
-      "end": "2019-01-03", 
+      "end": "2018-09-30", 
       "fax": "202-225-9061", 
       "office": "1609 Longworth House Office Building", 
       "party": "Republican", 


### PR DESCRIPTION
Rep. Evan Jenkins (WV-03) ended his term early because he resigned, and as a result his score and votes weren't in the scores data for session 115 (similar to the [John McCain data issues](https://github.com/aclu-national/scorecards/issues/68)). 

This updates his term end date and adds his votes to the scores doc.