### PR TITLE
Update Jon Kyl's term end date

### DIFF
--- a/data/congress_legislators/az/congress_legislator_az_jon-kyl.json
+++ b/data/congress_legislators/az/congress_legislator_az_jon-kyl.json
@@ -94,7 +94,7 @@
       "address": "G12 Dirksen Senate Office Building Washington DC 20510", 
       "class": 3, 
       "contact_form": "", 
-      "end": "2020-11-03", 
+      "end": "2018-12-31", 
       "end-type": "special-election", 
       "fax": "202-228-2862", 
       "how": "appointment", 


### PR DESCRIPTION
Jon Kyl, who replaced John McCain as Arizona's senator in session 115, wasn't showing up in the `v2/congress/legislators?session=115` endpoint because his end date was set to November 3, 2020. This corrects his term end date, as he stepped down at the end of 2018. 

Related: 
- Running list of manual data edits https://github.com/aclu-national/elections-api/issues/11
- Thinking through our process for updating historical legislator data https://github.com/aclu-national/elections-api/issues/13