### PR TITLE
Don't append scores after end of term

### DIFF
--- a/server/api/v2/congress.py
+++ b/server/api/v2/congress.py
@@ -448,6 +448,19 @@ def get_legislators(cur, score_filter="total", include=None, session_num=curr_se
 			legislators[aclu_id]['social'][key] = value
 
 	if score_filter == 'all':
+
+		vote_dates = {}
+		cur.execute('''
+			SELECT aclu_id, vote_date
+			FROM congress_legislator_score_index
+		''')
+		rs = cur.fetchall()
+		if rs:
+			for row in rs:
+				vote_id = row[0]
+				vote_date = arrow.get(row[1]).format('YYYY-MM-DD')
+				vote_dates[vote_id] = vote_date
+
 		cur.execute('''
 			SELECT aclu_id, session, legislator_id, position, name, value
 			FROM congress_legislator_scores
@@ -535,7 +548,10 @@ def get_legislators(cur, score_filter="total", include=None, session_num=curr_se
 					if s['session'] == session:
 						if not 'scores' in s:
 							s['scores'] = []
-						s['scores'].append(score)
+						id = score['aclu_id']
+						score['vote_date'] = vote_dates[id]
+						if score['vote_date'] <= legislators[legislator_id]['term']['end_date']:
+							s['scores'].append(score)
 
 	cur.execute('''
 		SELECT legislator_id, session

--- a/server/api/v2/congress.py
+++ b/server/api/v2/congress.py
@@ -458,8 +458,7 @@ def get_legislators(cur, score_filter="total", include=None, session_num=curr_se
 		if rs:
 			for row in rs:
 				vote_id = row[0]
-				vote_date = arrow.get(row[1]).format('YYYY-MM-DD')
-				vote_dates[vote_id] = vote_date
+				vote_dates[vote_id] = arrow.get(row[1]).format('YYYY-MM-DD')
 
 		cur.execute('''
 			SELECT aclu_id, session, legislator_id, position, name, value
@@ -550,6 +549,10 @@ def get_legislators(cur, score_filter="total", include=None, session_num=curr_se
 							s['scores'] = []
 						id = score['aclu_id']
 						score['vote_date'] = vote_dates[id]
+
+						# This conditional exists to ensure we don't include
+						# votes that occur after someone's term ends (e.g., they
+						# pass away). (20191028/dphiffer)
 						if score['vote_date'] <= legislators[legislator_id]['term']['end_date']:
 							s['scores'].append(score)
 


### PR DESCRIPTION
Excludes scores whose `vote_date` is after the legislator's term's `end_date`. Also adds a `vote_date` property to the scores to help make sense of when they get filtered out.

__Before__:

```
$ curl -s "http://localhost:5000/v2/congress/legislators?url_slug=az-john-mccain" | jq ".congress_legislators[0].sessions[0].scores[].aclu_id"  
"aclu/us-congress-115/sen_score:1"
"aclu/us-congress-115/sen_score:2"
"aclu/us-congress-115/sen_score:3"
"aclu/us-congress-115/sen_score:4"
"aclu/us-congress-115/sen_score:5"
"aclu/us-congress-115/sen_score:6"
"aclu/us-congress-115/sen_score:7"
"aclu/us-congress-115/sen_score:8"
"aclu/us-congress-115/sen_score:9"
"aclu/us-congress-115/sen_score:10"
"aclu/us-congress-115/sen_score:11"
"aclu/us-congress-115/sen_score:12"
"aclu/us-congress-115/sen_score:13"
"aclu/us-congress-115/sen_score:14"
"aclu/us-congress-115/sen_score:15"
"aclu/us-congress-115/sen_score:16"
"aclu/us-congress-115/sen_score:17"
"aclu/us-congress-115/sen_score:18"
"aclu/us-congress-115/sen_score:19"
"aclu/us-congress-115/sen_score:20"
"aclu/us-congress-115/sen_score:21"
"aclu/us-congress-115/sen_score:22"
"aclu/us-congress-115/sen_score:23"
```

__After__:

```
$ curl -s "http://localhost:5000/v2/congress/legislators?url_slug=az-john-mccain" | jq ".congress_legislators[0].sessions[0].scores[].aclu_id"
"aclu/us-congress-115/sen_score:1"
"aclu/us-congress-115/sen_score:2"
"aclu/us-congress-115/sen_score:3"
"aclu/us-congress-115/sen_score:4"
"aclu/us-congress-115/sen_score:5"
"aclu/us-congress-115/sen_score:6"
"aclu/us-congress-115/sen_score:7"
"aclu/us-congress-115/sen_score:8"
"aclu/us-congress-115/sen_score:9"
"aclu/us-congress-115/sen_score:10"
"aclu/us-congress-115/sen_score:11"
"aclu/us-congress-115/sen_score:12"
"aclu/us-congress-115/sen_score:13"
"aclu/us-congress-115/sen_score:14"
"aclu/us-congress-115/sen_score:15"
"aclu/us-congress-115/sen_score:16"
"aclu/us-congress-115/sen_score:17"
"aclu/us-congress-115/sen_score:18"
"aclu/us-congress-115/sen_score:19"
"aclu/us-congress-115/sen_score:20"
"aclu/us-congress-115/sen_score:21"
```