### PR TITLE
Only add vote counts once per legislator row

### DIFF
--- a/scripts/index_congress_scores.py
+++ b/scripts/index_congress_scores.py
@@ -171,9 +171,9 @@ if __name__ == "__main__":
 						cur.execute(legislator_score_insert_sql, values)
 						col_num += 1
 
-						congress_details.add_legislator_detail(legislator_id, session, 'votes_total', votes_total)
-						congress_details.add_legislator_detail(legislator_id, session, 'votes_agreed', votes_agreed)
-						congress_details.add_legislator_detail(legislator_id, session, 'total_score', total_score)
+					congress_details.add_legislator_detail(legislator_id, session, 'votes_total', votes_total)
+					congress_details.add_legislator_detail(legislator_id, session, 'votes_agreed', votes_agreed)
+					congress_details.add_legislator_detail(legislator_id, session, 'total_score', total_score)
 
 				row_num = row_num + 1
 


### PR DESCRIPTION
The score indexing script was adding vote count details to the `congress_legislator_details` table for each vote cast by a legislator, instead of for each legislator.

I think this PR fixes the bug I was seeing locally, where there was a discrepancy for some vote counts between `localhost:5000/v2/congress/legislators` and `localhost:5000/v2/congress/legislators?url_slug=URL_SLUG`.