### PR TITLE
Allow for votes from previous terms

### DIFF
--- a/server/api/v2/congress.py
+++ b/server/api/v2/congress.py
@@ -590,9 +590,9 @@ def get_legislators(cur, score_filter="total", include=None, session_num=curr_se
 						# votes that occur inside of a time span bounded by
 						# the legislators start/end dates. (20191101/dphiffer)
 						#
-						# Modified the conditional to allow for votes that occurred
-						# during a legislator's previous terms! (20191113/kokonakajima)
-						if score['vote_date'] <= end_date and score['status'] != "Not in office":
+						# Modified the conditional to treat the spreadsheet
+						# vote label as the source of truth (20191113/kokonakajima)
+						if score['status'] != "Not in office":
 							s['scores'].append(score)
 
 	cur.execute('''

--- a/server/api/v2/congress.py
+++ b/server/api/v2/congress.py
@@ -589,7 +589,10 @@ def get_legislators(cur, score_filter="total", include=None, session_num=curr_se
 						# This conditional exists to ensure we only include
 						# votes that occur inside of a time span bounded by
 						# the legislators start/end dates. (20191101/dphiffer)
-						if score['vote_date'] <= end_date and score['vote_date'] >= start_date:
+						#
+						# Modified the conditional to allow for votes that occurred
+						# during a legislator's previous terms! (20191113/kokonakajima)
+						if score['vote_date'] <= end_date and score['status'] != "Not in office":
 							s['scores'].append(score)
 
 	cur.execute('''


### PR DESCRIPTION
Noticed that votes for NJ senator Bob Menendez from session 115 weren't showing up in his scorecard and individual endpoint https://elections-stg.api.aclu.org/v2/congress/legislators?url_slug=nj-robert-menendez:
```
{
"display_name": "Sen. Robert \"Bob\" Menendez",
"running_for_president": false,
"running_in_2018": true,
"scores": [],
"session": 115,
"total_score": "78%",
"votes_agreed": "21",
"votes_total": "27"
},
``` 

I think it has to do with the following score filter, which doesn't return votes if they occurred before a legislator's most recent term (for people like Jon Kyl, who has vote data from before he took office).
```
if score['vote_date'] <= end_date and score['vote_date'] >= start_date:
  s['scores'].append(score)
```

The issue with Sen. Menendez's case is that he's served multiple terms, so he may have votes from before his current term's start date, but those wouldn't be returned. I think there'd be similar issues for any legislators who have served multiple terms that span multiple sessions.

This PR modifies the score filter to check for a `Not in office` status instead of comparing the vote date to the term start date. 

(This might need some more thinking through, because it's dependent on there being a correct label, `Not in office` or `Not yet in office`, in the spreadsheet. Alternatively, we could adjust the logic to check against all of a legislator's terms)