### PR TITLE
update bioguide and wikipedia scripts

### DIFF
--- a/scripts/source_congress_photos_bioguide.py
+++ b/scripts/source_congress_photos_bioguide.py
@@ -14,7 +14,7 @@ data = yaml.load(file)
 
 for legislator in data:
 	bioguide = legislator["id"]["bioguide"]
-	url = "http://bioguide.congress.gov/bioguide/photo/%s/%s.jpg" % (bioguide[0], bioguide)
+	url = "https://bioguideretro.congress.gov/Static_Files/images/photos/%s/%s.jpg" % (bioguide[0], bioguide)
 	path = "%s/sources/congress_photos/%s.jpg" % (root_dir, bioguide)
 	if not os.path.exists(path):
 		cmd = ["/usr/bin/curl", "--fail", "-s", "-o", path, url]


### PR DESCRIPTION
A new http://bioguide.congress.gov/ is coming soon, and the path we've been using to pull our images no longer work. This fixes the path for now, but we will likely need to update this again once the new site launches. 

I also realized we were missing the [pup](https://github.com/ericchiang/pup) dependency for the wikipedia script in Docker. I was having some trouble installing this in docker though, and since we don't use it anywhere else, it seemed easier to rewrite how we scrape wikipedia for the image. I removed the dependency on pup and use the wikipedia API to grab the image url from the JSON instead. Not sure if there's a reason we were scraping the page rather than using the API? 