### PR TITLE
add support for querying state endpoint by state abbreviation

### DIFF
--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -122,6 +122,7 @@ Arguments:
 * `geometry`: Include GeoJSON geometries with districts (optional; geometry=1)
 * `lat`: Latitude
 * `lng`: Longitude
+* `state`: Instead of lat/lng or id, specify a state (e.g., state=ny)
 
 [Example lookup](https://elections.api.aclu.org/v2/state?lat=40.7023587&lng=-74.0124621) | [Example response](./responses/v2-state.js)
 

--- a/server/api/v2/__init__.py
+++ b/server/api/v2/__init__.py
@@ -309,10 +309,13 @@ def state():
 			'error': req
 		})
 
-	lat = req['lat']
-	lng = req['lng']
+	if 'lat' in req and 'lng' in req:
+		rsp = state_api.get_state_by_coords(req['lat'], req['lng'])
+	elif 'state' in req:
+		rsp = state_api.get_state_by_id(req['state'])
+	else:
+		rsp = None
 
-	rsp = state_api.get_state_by_coords(lat, lng)
 	if rsp == None:
 		return flask.jsonify({
 			'ok': False,

--- a/server/api/v2/__init__.py
+++ b/server/api/v2/__init__.py
@@ -43,6 +43,7 @@ def index():
 				'args': {
 					'lat': 'Latitude',
 					'lng': 'Longitude',
+					'state': 'Instead of lat/lng or id, specify a state (e.g., state=ny)',
 					'geometry': 'Include GeoJSON geometries with districts (optional; geometry=1)'
 				}
 			},


### PR DESCRIPTION
Fixes #51 

This adds support to the `/v2/state` endpoint for a new query param `state` that takes the abbreviation of a state, e.g. `ny`, as opposed to a `lat` and `lng`. 

It's a bit repetitive to say /v2/state?state=ny but this follows the convention used for /v2/pip and /v2/calendar.