### PR TITLE
adjust timeframe of term search

### DIFF
--- a/server/api/v2/congress.py
+++ b/server/api/v2/congress.py
@@ -209,8 +209,7 @@ def get_legislators_by_state(state, session_num=curr_session):
 		SELECT id, aclu_id, start_date, end_date, type, state, district_num, party
 		FROM congress_legislator_terms
 		WHERE (
-			start_date >= '{start_date}' AND end_date <= '{end_date}'
-			OR start_date <= '{start_date}' AND end_date >= '{end_date}'
+			end_date > '{start_date}' AND start_date < '{end_date}'
 		)
 		AND state = %s
 		ORDER BY end_date DESC


### PR DESCRIPTION
I noticed [Sen. Rick Scott](https://elections.api.aclu.org/v2/state?state=fl) wasn't appearing in location searches, and discovered an issue with how we query legislators by term date. In the example below, Sen. Scott is scenario C, because his term started later than most and extends past the end date of the session. Right now we are only returning scenarios B and D. I believe scenario A should still be returned and the front-end can decide whether or not to show legislators who have ended their term early.

Since end dates of a term are equal to start dates of the next term, I wrote the query so that it excludes terms that end on the first day of a session or terms that start on the last day of a session. 

Here's a little sketch of different scenarios to cover, where the ones in red (A, B, C, D) are the ones I believe we should return. 

![IMG_1565](https://user-images.githubusercontent.com/350906/93901779-e12f8980-fcc4-11ea-93d8-54b0abab4f28.jpg)

