### PR TITLE
Check existing ids before adding/updating legislator records

### DIFF
--- a/scripts/data_congress_legislators.py
+++ b/scripts/data_congress_legislators.py
@@ -29,8 +29,6 @@ legislator_list = []
 for legislator in data:
 	id = legislator["id"]["bioguide"]
 	legislator_lookup[id] = legislator
-	if (id not in existing_legislator_lookup):
-		legislator_list.append(legislator)
 
 source_path = "%s/sources/congress_legislators/legislators-social-media.yaml" % root_dir
 print("Loading %s" % source_path)
@@ -74,15 +72,22 @@ def sort_legislators(a, b):
 
 legislator_list.sort(sort_legislators)
 
-for legislator in legislator_list:
+# TODO: sort the list of keys instead?
+for bioguide_id in legislator_lookup:
+	legislator = legislator_lookup[bioguide_id]
 
-	filename = get_filename(legislator)
-	state = legislator["terms"][0]["state"].lower()
+	if (bioguide_id in existing_legislator_lookup):
+		path_index = 1
+		path = existing_legislator_lookup[bioguide_id][path_index]
+	else:
+		filename = get_filename(legislator)
+		state = legislator["terms"][0]["state"].lower()
+		path = "congress_legislators/%s/%s" % (state, filename)
+
 	fname = legislator["name"]["first"]
 	lname = legislator["name"]["last"]
 	name = "%s %s" % (fname, lname)
 
-	path = "congress_legislators/%s/%s" % (state, filename)
 	abs_path = "%s/data/%s" % (root_dir, path)
 
 	aclu_id = data_index.get_id('elections-api', 'congress_legislator', path, name)

--- a/scripts/data_congress_legislators.py
+++ b/scripts/data_congress_legislators.py
@@ -7,6 +7,17 @@ script = os.path.realpath(sys.argv[0])
 scripts_dir = os.path.dirname(script)
 root_dir = os.path.dirname(scripts_dir)
 
+# Build lookup of existing legislators to avoid duplicate records
+existing_legislator_lookup = {}
+index = data_index.get_index('elections-api')
+for path in index['lookup'] :
+	if ('congress_legislators' in path) :
+		abs_path = "%s/data/%s" % (root_dir, path)
+		with open(abs_path, 'r') as f:
+			legislator = json.load(f)
+			bioguide_id = legislator['id']['bioguide']
+			existing_legislator_lookup[bioguide_id] = index['lookup'][path]
+
 source_path = "%s/sources/congress_legislators/legislators-current.yaml" % root_dir
 print("Loading %s" % source_path)
 file = open(source_path, "r")
@@ -18,7 +29,8 @@ legislator_list = []
 for legislator in data:
 	id = legislator["id"]["bioguide"]
 	legislator_lookup[id] = legislator
-	legislator_list.append(legislator)
+	if (id not in existing_legislator_lookup):
+		legislator_list.append(legislator)
 
 source_path = "%s/sources/congress_legislators/legislators-social-media.yaml" % root_dir
 print("Loading %s" % source_path)


### PR DESCRIPTION
Ran into this issue when adding new legislator records for the 117th session: 
- We currently use a legislator's first and last name (as listed in unitedstates/legislators.current.yaml) to construct the path to their json data file. Sometimes the first or last name listed changes between data updates, causing the script to create new json records instead of updating existing ones. This leads to duplicate legislator records and multiple aclu_ids assigned to the same person. 

This PR prevents duplicate records by cross-referencing legislators' bioguide IDs, which shouldn't change between data updates.