### PR TITLE
ues relative path for server file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.7'
 services:
   elections-api:
     build: ./server
-    command: python server/server.py run -h 0.0.0.0
+    command: python ./server/server.py run -h 0.0.0.0
     volumes:
       - ./:/usr/local/aclu/elections-api
     ports:


### PR DESCRIPTION
I had a problem Docker not being able to find `server/server.py`, so had to use the relative path. (I am using Docker v20.10.2)
🤔  is there any reason we were not using a relative path for `server.py`?